### PR TITLE
A.D.1.4 definition

### DIFF
--- a/lineages/A.D.1.4.yml
+++ b/lineages/A.D.1.4.yml
@@ -1,0 +1,27 @@
+defining_mutations:
+- locus: F
+  position: 3
+  state: S
+- locus: G
+  position: 122
+  state: V
+- locus: G
+  position: 273
+  state: H
+- locus: L
+  position: 1735
+  state: D
+- locus: L
+  position: 1934
+  state: I
+name: A.D.1.4
+parent: A.D.1
+representatives:
+- OQ024155
+- OR143137
+- OY757595
+- PP352344
+- PP681283
+- PP770472
+
+unaliased_name: A.3.1.1.1.1.4


### PR DESCRIPTION
This adds lineages/A.D.1.4.yml to define the lineage proposed in #2.

The defining_mutations are a subset of the many amino acid mutations in this lineage relative to its parent A.D.1, chosen because they occur closer to the start of the lineage in the UShER RSV-A tree, i.e. the green branch in [this view](https://nextstrain.org/fetch/hgwdev.gi.ucsc.edu/~angie/RSV-ld-A-2.json?c=gt-L_1656,1735&gmax=14995&gmin=8498&label=id:node_1749) (note: the UShER RSV-A tree uses RefSeq NC_038235.1 as reference so its G coordinates are a little different.  In A.D.1.4.yml, I used G coordinates from Alan's nextclade tree in #2, which presumably uses the nextclade RSV-A reference).

<img width="1184" alt="image" src="https://github.com/rsv-lineages/lineage-designation-A/assets/186983/61730298-1664-446c-944b-c390030f165e">
