### PR TITLE
add three additional A.D.1 sublineages

### DIFF
--- a/lineages/A.D.1.5.yml
+++ b/lineages/A.D.1.5.yml
@@ -1,0 +1,15 @@
+defining_mutations:
+- locus: F
+  position: 127
+  state: I
+- locus: M2-1
+  position: 180
+  state: A
+name: A.D.1.5
+parent: A.D.1
+representatives:
+- OQ171906
+- PP352349
+- OR883018
+- OR143171
+unaliased_name: A.3.1.1.1.1.5

--- a/lineages/A.D.1.6.yml
+++ b/lineages/A.D.1.6.yml
@@ -1,0 +1,17 @@
+defining_mutations:
+- locus: G
+  position: 106
+  state: E
+- locus: L
+  position: 1225
+  state: I
+- locus: L
+  position: 1690
+  state: Y
+name: A.D.1.6
+parent: A.D.1
+representatives:
+- PP352345
+- PP135017
+- PP795136
+unaliased_name: A.3.1.1.1.1.6

--- a/lineages/A.D.1.6.yml
+++ b/lineages/A.D.1.6.yml
@@ -3,8 +3,8 @@ defining_mutations:
   position: 106
   state: E
 - locus: L
-  position: 1225
-  state: I
+  position: 1724
+  state: D
 - locus: L
   position: 1690
   state: Y

--- a/lineages/A.D.1.7.yml
+++ b/lineages/A.D.1.7.yml
@@ -1,0 +1,17 @@
+defining_mutations:
+- locus: F
+  position: 57
+  state: V
+- locus: F
+  position: 111
+  state: I
+- locus: F
+  position: 122
+  state: A
+name: A.D.1.7
+parent: A.D.1
+representatives:
+- OQ171911
+- OR872616
+- PP203260
+unaliased_name: A.3.1.1.1.1.7


### PR DESCRIPTION
the A.D.1 group has a number of big sub clades that are quite distinct and/or have note worthy mutations. 

Proposed A.D.1.5 and A.D.1.7 in orange and green:

![image](https://github.com/user-attachments/assets/27bbb745-2d7e-4f39-bfcf-985f4400838e)

putative A.D.1.7 has 3 mutations in F.

A.D.1.6 has a distinct long branch:

![image](https://github.com/user-attachments/assets/961267f7-ba19-4833-8780-aac8692dc00a)
