### PR TITLE
add subclades of A.D.3 suggested by Stephanie

### DIFF
--- a/lineages/A.D.3.1.yml
+++ b/lineages/A.D.3.1.yml
@@ -10,5 +10,8 @@ defining_mutations:
   state: S
 name: A.D.3.1
 parent: A.D.3
-representatives: []
+representatives:
+ - PP376548
+ - OR795445
+ - OR522470
 unaliased_name: A.3.1.1.1.3.1

--- a/lineages/A.D.3.2.yml
+++ b/lineages/A.D.3.2.yml
@@ -1,0 +1,20 @@
+defining_mutations:
+- locus: L
+  position: 1653
+  state: V
+- locus: F
+  position: 276
+  state: N
+- locus: M
+  position: 96
+  state: I
+- locus: NS1
+  position: 71
+  state: V
+name: A.D.3.2
+parent: A.D.3
+representatives:
+ - PP508181
+ - OR143195
+ - PP135024
+unaliased_name: A.3.1.1.1.3.2

--- a/lineages/A.D.3.3.yml
+++ b/lineages/A.D.3.3.yml
@@ -1,0 +1,17 @@
+defining_mutations:
+- locus: M2-2
+  position: 47
+  state: Y
+- locus: G
+  position: 204
+  state: N
+- locus: NS1
+  position: 2
+  state: D
+name: A.D.3.3
+parent: A.D.3
+representatives:
+ - PP748752
+ - PP530269
+ - PP770461
+unaliased_name: A.3.1.1.1.3.3

--- a/lineages/A.D.3.4.yml
+++ b/lineages/A.D.3.4.yml
@@ -1,0 +1,20 @@
+defining_mutations:
+- locus: F
+  position: 114
+  state: Y
+- locus: G
+  position: 204
+  state: R
+- locus: L
+  position: 559
+  state: S
+- locus: L
+  position: 1314
+  state: M
+name: A.D.3.4
+parent: A.D.3
+representatives:
+ - OQ261753
+ - OQ024115
+ - OR143204
+unaliased_name: A.3.1.1.1.3.4

--- a/lineages/A.D.3.5.yml
+++ b/lineages/A.D.3.5.yml
@@ -1,0 +1,20 @@
+defining_mutations:
+- locus: M2-2
+  position: 44
+  state: L
+- locus: F
+  position: 20
+  state: F
+- locus: M
+  position: 43
+  state: I
+- locus: N
+  position: 129
+  state: Y
+name: A.D.3.5
+parent: A.D.3
+representatives:
+ - OR795475
+ - PP781414
+ - PP709453
+unaliased_name: A.3.1.1.1.3.5

--- a/lineages/A.D.3.6.yml
+++ b/lineages/A.D.3.6.yml
@@ -1,0 +1,20 @@
+defining_mutations:
+- locus: M2-1
+  position: 20
+  state: K
+- locus: G
+  position: 151
+  state: H
+- locus: M2-2
+  position: 23
+  state: A
+- locus: NS2
+  position: 35
+  state: V
+name: A.D.3.6
+parent: A.D.3
+representatives:
+ - PP237786
+ - PP401817
+ - PP504647
+unaliased_name: A.3.1.1.1.3.6


### PR DESCRIPTION
This adds 5 additional subclades of A.D.3 as suggested by Stephanie. 

The suggestions have a sufficient number of amino acids, but the 'bushiness' of the A.D.3 makes finding clear demarcation lines difficult. Some of these novel lineages are already rather diverse. 